### PR TITLE
fix faq toggle behavior

### DIFF
--- a/index.html
+++ b/index.html
@@ -324,9 +324,9 @@
           </li>
 
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed  text-light">What will be asked in the interview? <i
+            <a data-toggle="collapse" href="#faq2" class="collapsed  text-light">What will be asked in the interview? <i
                 class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq2" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 Your thought process, your work ethics and your ability to learn something new are some of the things
                 that are taken into consideration. We need motivated people who can work as a team. The questions asked
@@ -337,10 +337,10 @@
           </li>
 
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed  text-light"> I am not that good at technical things
+            <a data-toggle="collapse" href="#faq3" class="collapsed  text-light"> I am not that good at technical things
               currently, should I give the interview?
               <i class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq3" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 Technical skills are important but that is not the only parameter that is considered in the interviews,
                 so feel free to appear for the interviews. As a fresher student, we do not expect each person to be good
@@ -354,10 +354,10 @@
           </li>
 
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed  text-light">Are there any prerequisites to join
+            <a data-toggle="collapse" href="#faq4" class="collapsed  text-light">Are there any prerequisites to join
               Team Vibhav?
               <i class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq4" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 We are just looking for competent people, there are no prerequisites as such. You just need to have the
                 zeal to work for the team.
@@ -366,10 +366,10 @@
           </li>
 
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed  text-light">In what kind of domains Team Vibhav
+            <a data-toggle="collapse" href="#faq5" class="collapsed  text-light">In what kind of domains Team Vibhav
               make their projects?
               <i class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq5" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 We mainly focus on electronics based projects like embedded systems, circuit logics and also align to
                 computer science related projects like in the field of machine learning, AR/VR, Web and App Development.
@@ -379,9 +379,9 @@
           </li>
 
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed text-light">Can we join two teams simultaneously?<i
+            <a data-toggle="collapse" href="#faq6" class="collapsed text-light">Can we join two teams simultaneously?<i
                 class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq6" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 Yes, you can join two Nimbus teams simultaneously, but we do not recommend joining two teams because the
                 work schedule will be overly hectic and you will not be able to give your 100% in any of the teams
@@ -391,10 +391,10 @@
             </div>
           </li>
           <li>
-            <a data-toggle="collapse" href="#faq1" class="collapsed text-light">What else can I learn by joining Team
+            <a data-toggle="collapse" href="#faq7" class="collapsed text-light">What else can I learn by joining Team
               Vibhav?
               <i class="ion-android-remove"></i></a>
-            <div id="faq1" class="collapse" data-parent="#faq-list">
+            <div id="faq7" class="collapse" data-parent="#faq-list">
               <p class="text-light text-justify">
                 You will learn how to implement technology in real world problems by building prototypes from your
                 ideas. Being a club abiding by - ‘Technology for a Cause’, we adhere to acceptable solutions for prime


### PR DESCRIPTION
This pull request addresses Issue #17 Frequently asked questions toggle fix

**Previous Behavior:** When a user clicked on any one of the first 7 accordion toggles in the FAQ section, all 7 would open up. 
<details>

![Previous behavior](https://user-images.githubusercontent.com/54963017/135615565-ef7ce975-ecf5-4deb-9503-276093254d23.png)

</details>


**Updated Behavior:** When a user clicks on any of the accordion toggles in the FAQ section, only that toggle opens up. The example below only shows one, but each toggle has been checked and they are all functioning properly. 

![Updated behavior](https://user-images.githubusercontent.com/54963017/135615606-2588073e-58f2-4b83-9833-f583feb0fa45.png)


