### PR TITLE
Fixed Social Media Icons not visible

### DIFF
--- a/css/style.css
+++ b/css/style.css
@@ -1445,9 +1445,6 @@ hr {
 #team .member:hover .member-info-content {
     height: 80px;
 }
-.bug .member:hover .member-info-content {
-    height: 40px !important;
-}
 
 #team .member h4 {
     font-weight: 700;


### PR DESCRIPTION
Issue Social media icon not visible on hovering on cards #28   is resolved with this PR.
Previous Behaviour : On hovering any member card on team page the social media handles were not visible.
![Screenshot (546)](https://user-images.githubusercontent.com/41839176/135709915-2fe5d5a4-cada-4a0f-b737-c18a5078c144.png)
 
Updated Behaviour : Now the social media handles are visible on hovering any member card.
![Screenshot (545)](https://user-images.githubusercontent.com/41839176/135709961-286d7e3f-77e4-4946-9a3e-3466d48709f2.png)
